### PR TITLE
Removes Pills' Ability To Get Dirty

### DIFF
--- a/code/modules/reagents/reagent_containers/pill.dm
+++ b/code/modules/reagents/reagent_containers/pill.dm
@@ -22,8 +22,6 @@
 		icon_state = "pill[rand(1,20)]"
 	if(reagents.total_volume && rename_with_volume)
 		name += " ([reagents.total_volume]u)"
-	if(apply_type == INGEST)
-		AddComponent(/datum/component/germ_sensitive, mapload)
 
 ///Runs the consumption code, can be overriden for special effects
 /obj/item/reagent_containers/pill/proc/on_consumption(mob/consumer, mob/giver)


### PR DESCRIPTION
## About The Pull Request

This PR removes the germ_sensitive component on pills, making them unable to get dirty and make you sick anymore.

## Why It's Good For The Game

Everyone loves a good floor pill, and knowing you'll get sick if you eat one puts a damper on the roulette of bad shit you're already rolling. So let's just not?

## Changelog

:cl:
balance: Removed pills getting dirty and making you sick. Floor pill enjoyers rejoice!
/:cl: