### PR TITLE
Gives the station's starting ore vent more material types on low pop.

### DIFF
--- a/code/game/objects/structures/lavaland/ore_vent.dm
+++ b/code/game/objects/structures/lavaland/ore_vent.dm
@@ -472,6 +472,31 @@
 		/datum/material/glass = 50,
 	)
 
+/obj/structure/ore_vent/starter_resources/Initialize(mapload)
+	. = ..()
+	var/list/super_low_pop_mats = list(
+		/datum/material/plastic = 20,
+		/datum/material/plasma = 10,
+		/datum/material/titanium = 10,
+		/datum/material/silver = 5,
+		/datum/material/gold = 5,
+		/datum/material/diamond = 1,
+		/datum/material/uranium = 1,
+		/datum/material/bluespace = 1,
+	)
+	var/list/low_pop_mats = list(
+		/datum/material/plastic = 10,
+		/datum/material/plasma = 5,
+		/datum/material/titanium = 1,
+		/datum/material/silver = 1,
+		/datum/material/gold = 1,
+	)
+	var/player_count = length(GLOB.alive_player_list)
+	if(player_count <= 10)
+		mineral_breakdown |= super_low_pop_mats
+	if(player_count <= 20 && player_count >= 11)
+		mineral_breakdown |= low_pop_mats
+
 /obj/structure/ore_vent/random
 
 /obj/structure/ore_vent/random/Initialize(mapload)


### PR DESCRIPTION
## About The Pull Request

Just a little quality-of-life change i recently added on my server. Thought you'd want it too.

## Why It's Good For The Game

Prevents low pop rounds from consistently being mat-less. Low pop hardly ever has miners, since they're either not on the server or they see how little people they'd be providing for and feel discouraged.

## Changelog

:cl:
add: The station's starting ore vent can now provide all or additional material types should the total crew size be less than twenty.
/:cl:
