### PR TITLE
Increased Manual Mining Ores

### DIFF
--- a/code/__DEFINES/mining.dm
+++ b/code/__DEFINES/mining.dm
@@ -40,24 +40,24 @@
 /// The chance of ore spawning in a wall that is VENT_PROX_VERY_HIGH tiles to a vent.
 #define VENT_CHANCE_VERY_HIGH 75
 /// The chance of ore spawning in a wall that is VENT_PROX_HIGH tiles to a vent.
-#define VENT_CHANCE_HIGH 18
+#define VENT_CHANCE_HIGH 20
 /// The chance of ore spawning in a wall that is VENT_PROX_MEDIUM tiles to a vent.
-#define VENT_CHANCE_MEDIUM 9
+#define VENT_CHANCE_MEDIUM 12
 /// The chance of ore spawning in a wall that is VENT_PROX_LOW tiles to a vent.
-#define VENT_CHANCE_LOW 5
+#define VENT_CHANCE_LOW 6
 /// The chance of ore spawning in a wall that is VENT_PROX_FAR tiles to a vent.
-#define VENT_CHANCE_FAR 1
+#define VENT_CHANCE_FAR 3
 
 /// The amount of ore that is mined from a wall that is VENT_PROX_VERY_HIGH tiles to a vent.
-#define ORE_WALL_VERY_HIGH 7
+#define ORE_WALL_VERY_HIGH 9
 /// The amount of ore that is mined from a wall that is VENT_PROX_HIGH tiles to a vent.
-#define ORE_WALL_HIGH 6
+#define ORE_WALL_HIGH 7
 /// The amount of ore that is mined from a wall that is VENT_PROX_MEDIUM tiles to a vent.
-#define ORE_WALL_MEDIUM 4
+#define ORE_WALL_MEDIUM 5
 /// The amount of ore that is mined from a wall that is VENT_PROX_LOW tiles to a vent.
-#define ORE_WALL_LOW 3
+#define ORE_WALL_LOW 4
 /// The amount of ore that is mined from a wall that is VENT_PROX_FAR tiles to a vent.
-#define ORE_WALL_FAR 2
+#define ORE_WALL_FAR 3
 
 /// The number of points a miner gets for discovering a vent, multiplied by BOULDER_SIZE when completing a wave defense minus the discovery bonus.
 #define MINER_POINT_MULTIPLIER 100

--- a/code/__DEFINES/mining.dm
+++ b/code/__DEFINES/mining.dm
@@ -49,15 +49,15 @@
 #define VENT_CHANCE_FAR 1
 
 /// The amount of ore that is mined from a wall that is VENT_PROX_VERY_HIGH tiles to a vent.
-#define ORE_WALL_VERY_HIGH 5
+#define ORE_WALL_VERY_HIGH 7
 /// The amount of ore that is mined from a wall that is VENT_PROX_HIGH tiles to a vent.
-#define ORE_WALL_HIGH 4
+#define ORE_WALL_HIGH 6
 /// The amount of ore that is mined from a wall that is VENT_PROX_MEDIUM tiles to a vent.
-#define ORE_WALL_MEDIUM 3
+#define ORE_WALL_MEDIUM 4
 /// The amount of ore that is mined from a wall that is VENT_PROX_LOW tiles to a vent.
-#define ORE_WALL_LOW 2
+#define ORE_WALL_LOW 3
 /// The amount of ore that is mined from a wall that is VENT_PROX_FAR tiles to a vent.
-#define ORE_WALL_FAR 1
+#define ORE_WALL_FAR 2
 
 /// The number of points a miner gets for discovering a vent, multiplied by BOULDER_SIZE when completing a wave defense minus the discovery bonus.
 #define MINER_POINT_MULTIPLIER 100

--- a/code/game/turfs/closed/minerals.dm
+++ b/code/game/turfs/closed/minerals.dm
@@ -31,7 +31,7 @@
 	/// If we spawn a boulder like on the gulag, we use this in lou of mineralType
 	var/obj/item/boulder/spawned_boulder = null
 	/// How much ore we spawn when we're mining a mineralType.
-	var/mineralAmt = 3
+	var/mineralAmt = 4
 	///Holder for the image we display when we're pinged by a mining scanner
 	var/scan_state = ""
 	///If true, this turf will not call AfterChange during change_turf calls.


### PR DESCRIPTION
## About The Pull Request

This PR increases the amount of ores gained from manual mining across the board. Ore gain amounts when manual mining are determined by proximity to ore vents, what this PR does is increase the amount of the ores gathered regardless of locations by varying amounts, but enough to make an impact, along with making ore more likely to spawn away from vents.

## Why It's Good For The Game

When ArcMining came out on /tg/, the amount of ores gained from manual mining was decreased notably to encourage interaction with the new ore vent system, which was primarily meant to solve two problems:

- Ore income going away once the miners kill themselves (a concern we share), making most jobs annoying to do
- Getting too much ore too quickly to remove material scarcity from what was aimed to be a much longer round time (a concern we don't share)

If the miners want to go ham and get that ore, they should be rewarded. Our round times are aimed at a Sybil standard of 40 - 60 minutes more or less, so we don't need to be concerned with giving more ore if the players go and earn it.

Also, if you need to manual mine for whatever reason (maybe you're an antag and just need something specific), this also helps.

## Changelog

:cl:
balance: Manual mining ores are increased per wall and more ore walls spawn, especially away from vents.
/:cl: