### PR TITLE
Shutters now cost iron to make instead of plasteel.

### DIFF
--- a/code/datums/components/crafting/doors.dm
+++ b/code/datums/components/crafting/doors.dm
@@ -1,7 +1,7 @@
 /datum/crafting_recipe/shutters
 	name = "Shutters"
 	reqs = list(
-		/obj/item/stack/sheet/plasteel = 5,
+		/obj/item/stack/sheet/iron = 5,
 		/obj/item/stack/cable_coil = 5,
 		/obj/item/electronics/airlock = 1,
 	)

--- a/code/game/objects/items/stacks/sheets/sheet_types.dm
+++ b/code/game/objects/items/stacks/sheets/sheet_types.dm
@@ -148,7 +148,9 @@ GLOBAL_LIST_INIT(metal_recipes, list ( \
 	new/datum/stack_recipe("pestle", /obj/item/pestle, 1, time = 5 SECONDS, crafting_flags = NONE, category = CAT_CHEMISTRY), \
 	new/datum/stack_recipe("hygienebot assembly", /obj/item/bot_assembly/hygienebot, 2, time = 5 SECONDS, crafting_flags = NONE, category = CAT_ROBOT), \
 	new/datum/stack_recipe("shower frame", /obj/structure/showerframe, 2, time = 2 SECONDS, crafting_flags = NONE, category = CAT_FURNITURE), \
-	new/datum/stack_recipe("urinal", /obj/item/wallframe/urinal, 2, time = 1 SECONDS, crafting_flags = NONE, category = CAT_FURNITURE)
+	new/datum/stack_recipe("urinal", /obj/item/wallframe/urinal, 2, time = 1 SECONDS, crafting_flags = NONE, category = CAT_FURNITURE), \
+	null, \
+	new/datum/stack_recipe("shutter assembly", /obj/machinery/door/poddoor/shutters/preopen/deconstructed, 10, time = 5 SECONDS, crafting_flags = CRAFT_ONE_PER_TURF, category = CAT_DOORS)
 ))
 
 /obj/item/stack/sheet/iron
@@ -269,7 +271,6 @@ GLOBAL_LIST_INIT(plasteel_recipes, list ( \
 	new/datum/stack_recipe("AI core", /obj/structure/ai_core, 4, time = 5 SECONDS, crafting_flags = CRAFT_CHECK_DENSITY | CRAFT_ONE_PER_TURF, category = CAT_ROBOT),
 	new/datum/stack_recipe("bomb assembly", /obj/machinery/syndicatebomb/empty, 10, time = 5 SECONDS, crafting_flags = NONE, category = CAT_CHEMISTRY),
 	new/datum/stack_recipe("Large Gas Tank", /obj/structure/tank_frame, 4, time=1 SECONDS, crafting_flags = CRAFT_CHECK_DENSITY | CRAFT_ONE_PER_TURF, category = CAT_ATMOSPHERIC),
-	new/datum/stack_recipe("shutter assembly", /obj/machinery/door/poddoor/shutters/preopen/deconstructed, 5, time = 5 SECONDS, crafting_flags = CRAFT_ONE_PER_TURF, category = CAT_DOORS),
 	null,
 	new /datum/stack_recipe_list("airlock assemblies", list( \
 		new/datum/stack_recipe("high security airlock assembly", /obj/structure/door_assembly/door_assembly_highsecurity, 4, time = 5 SECONDS, crafting_flags = CRAFT_CHECK_DENSITY | CRAFT_ONE_PER_TURF | CRAFT_ON_SOLID_GROUND, category = CAT_DOORS),


### PR DESCRIPTION
## About The Pull Request

I was looking through the crafting menu code on my codebase and went: HOLY SHIT SHUTTERS COST PLASTEEL TO MAKE? WTF?

## Why It's Good For The Game

Likely the exact reason why I see nobody ever make these. Who the fuck just has stacks of plasteel lying around and thinks about making a few shutters?

## Changelog

Plasteel is no longer used to make shutters, instead that burden falls upon regular old iron.

:cl:
balance: Plasteel can no longer be used to make shutters. Shutters are now made with iron.
/:cl:
