### PR TITLE
Adds other departmental budget cards and additional bank machine functionality

### DIFF
--- a/code/game/gamemodes/objective_items.dm
+++ b/code/game/gamemodes/objective_items.dm
@@ -263,6 +263,84 @@
 /obj/item/card/id/departmental_budget/car/add_stealing_item_objective()
 	return add_item_to_steal(src, /obj/item/card/id/departmental_budget/car)
 
+/datum/objective_item/steal/traitor/eng_budget
+	name = "engineering's departmental budget"
+	targetitem = /obj/item/card/id/departmental_budget/eng
+	excludefromjob = list(JOB_CHIEF_ENGINEER, JOB_STATION_ENGINEER, JOB_ATMOSPHERIC_TECHNICIAN)
+	item_owner = list(JOB_CHIEF_ENGINEER)
+	exists_on_map = TRUE
+	difficulty = 2
+	steal_hint = "A card that grants access to Engineering's funds. \
+		Normally found in the locker of the Chief Engineer, but a particularly keen one may have it on their person or in their wallet."
+
+/obj/item/card/id/departmental_budget/eng/add_stealing_item_objective()
+	return add_item_to_steal(src, /obj/item/card/id/departmental_budget/eng)
+
+/datum/objective_item/steal/traitor/sci_budget
+	name = "science's departmental budget"
+	targetitem = /obj/item/card/id/departmental_budget/sci
+	excludefromjob = list(JOB_RESEARCH_DIRECTOR, JOB_SCIENTIST, JOB_ROBOTICIST)
+	item_owner = list(JOB_RESEARCH_DIRECTOR)
+	exists_on_map = TRUE
+	difficulty = 2
+	steal_hint = "A card that grants access to Science's funds. \
+		Normally found in the locker of the Research Director, but a particularly keen one may have it on their person or in their wallet."
+
+/obj/item/card/id/departmental_budget/sci/add_stealing_item_objective()
+	return add_item_to_steal(src, /obj/item/card/id/departmental_budget/sci)
+
+/datum/objective_item/steal/traitor/med_budget
+	name = "medical's departmental budget"
+	targetitem = /obj/item/card/id/departmental_budget/med
+	excludefromjob = list(JOB_CHIEF_MEDICAL_OFFICER, JOB_MEDICAL_DOCTOR, JOB_CHEMIST, JOB_PARAMEDIC, JOB_PSYCHOLOGIST)
+	item_owner = list(JOB_CHIEF_MEDICAL_OFFICER)
+	exists_on_map = TRUE
+	difficulty = 2
+	steal_hint = "A card that grants access to Medical's funds. \
+		Normally found in the locker of the Chief Medical Officer, but a particularly keen one may have it on their person or in their wallet."
+
+/obj/item/card/id/departmental_budget/med/add_stealing_item_objective()
+	return add_item_to_steal(src, /obj/item/card/id/departmental_budget/med)
+
+/datum/objective_item/steal/traitor/srv_budget
+	name = "service's departmental budget"
+	targetitem = /obj/item/card/id/departmental_budget/srv
+	excludefromjob = list(JOB_HEAD_OF_PERSONNEL, JOB_BOTANIST, JOB_CHEF, JOB_BARTENDER, JOB_CLOWN, JOB_MIME)
+	item_owner = list(JOB_HEAD_OF_PERSONNEL)
+	exists_on_map = TRUE
+	difficulty = 3
+	steal_hint = "A card that grants access to Service's funds. \
+		Normally found in the locker of the Head of Personnel, but a particularly keen one may have it on their person or in their wallet."
+
+/obj/item/card/id/departmental_budget/srv/add_stealing_item_objective()
+	return add_item_to_steal(src, /obj/item/card/id/departmental_budget/srv)
+
+/datum/objective_item/steal/traitor/civ_budget
+	name = "civilian's departmental budget"
+	targetitem = /obj/item/card/id/departmental_budget/civ
+	excludefromjob = list(JOB_HEAD_OF_PERSONNEL, JOB_ASSISTANT)
+	item_owner = list(JOB_HEAD_OF_PERSONNEL)
+	exists_on_map = TRUE
+	difficulty = 3
+	steal_hint = "A card that grants access to the Civilian budget. \
+		Normally found in the locker of the Head of Personnel, but a particularly keen one may have it on their person or in their wallet."
+
+/obj/item/card/id/departmental_budget/civ/add_stealing_item_objective()
+	return add_item_to_steal(src, /obj/item/card/id/departmental_budget/civ)
+
+/datum/objective_item/steal/traitor/sec_budget
+	name = "security's departmental budget"
+	targetitem = /obj/item/card/id/departmental_budget/sec
+	excludefromjob = list(JOB_HEAD_OF_SECURITY, JOB_WARDEN, JOB_DETECTIVE, JOB_SECURITY_OFFICER)
+	item_owner = list(JOB_HEAD_OF_SECURITY)
+	exists_on_map = TRUE
+	difficulty = 4
+	steal_hint = "A card that grants access to Security's funds. \
+		Normally found in the locker of the Head of Security, but a particularly keen one may have it on their person or in their wallet."
+
+/obj/item/card/id/departmental_budget/sec/add_stealing_item_objective()
+	return add_item_to_steal(src, /obj/item/card/id/departmental_budget/sec)
+
 /datum/objective_item/steal/traitor/captain_modsuit
 	name = "the captain's magnate MOD control unit"
 	targetitem = /obj/item/mod/control/pre_equipped/magnate

--- a/code/game/machinery/bank_machine.dm
+++ b/code/game/machinery/bank_machine.dm
@@ -51,6 +51,11 @@
 	else if(istype(weapon, /obj/item/holochip))
 		var/obj/item/holochip/inserted_holochip = weapon
 		value = inserted_holochip.credits
+	else if(istype(weapon, /obj/item/card/id/departmental_budget))
+		var/obj/item/card/id/departmental_budget/my_dep_card = weapon
+		account_department = my_dep_card.department_ID
+		say("Account department changed! Now accessing the funds of the [my_dep_card.name].")
+		synced_bank_account = SSeconomy.get_dep_account(account_department)
 	if(value)
 		if(synced_bank_account)
 			synced_bank_account.adjust_money(value)

--- a/code/game/objects/items/cards_ids.dm
+++ b/code/game/objects/items/cards_ids.dm
@@ -950,6 +950,36 @@
 	department_name = ACCOUNT_CAR_NAME
 	icon_state = "car_budget" //saving up for a new tesla
 
+/obj/item/card/id/departmental_budget/eng
+	department_ID = ACCOUNT_ENG
+	department_name = ACCOUNT_ENG_NAME
+	icon_state = "eng_budget"
+
+/obj/item/card/id/departmental_budget/sci
+	department_ID = ACCOUNT_SCI
+	department_name = ACCOUNT_SCI_NAME
+	icon_state = "sci_budget"
+
+/obj/item/card/id/departmental_budget/med
+	department_ID = ACCOUNT_MED
+	department_name = ACCOUNT_MED_NAME
+	icon_state = "med_budget"
+
+/obj/item/card/id/departmental_budget/srv
+	department_ID = ACCOUNT_SRV
+	department_name = ACCOUNT_SRV_NAME
+	icon_state = "srv_budget"
+
+/obj/item/card/id/departmental_budget/civ
+	department_ID = ACCOUNT_CIV
+	department_name = ACCOUNT_CIV_NAME
+	icon_state = "civ_budget"
+
+/obj/item/card/id/departmental_budget/sec
+	department_ID = ACCOUNT_SEC
+	department_name = ACCOUNT_SEC_NAME
+	icon_state = "sec_budget"
+
 /obj/item/card/id/departmental_budget/click_alt(mob/living/user)
 	registered_account.bank_card_talk(span_warning("Withdrawing is not compatible with this card design."), TRUE) //prevents the vault bank machine being useless and putting money from the budget to your card to go over personal crates
 	return CLICK_ACTION_BLOCKING

--- a/code/game/objects/structures/crates_lockers/closets/secure/engineering.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/engineering.dm
@@ -26,6 +26,7 @@
 	// Traitor steal objective
 	new /obj/item/blueprints(src)
 	new /obj/item/pipe_dispenser(src)
+	new /obj/item/card/id/departmental_budget/eng(src)
 
 /obj/structure/closet/secure_closet/engineering_electrical
 	name = "electrical supplies locker"

--- a/code/game/objects/structures/crates_lockers/closets/secure/medical.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/medical.dm
@@ -100,6 +100,7 @@
 
 	// Traitor steal objective
 	new /obj/item/reagent_containers/hypospray/cmo(src)
+	new /obj/item/card/id/departmental_budget/med(src)
 
 /obj/structure/closet/secure_closet/animal
 	name = "animal control locker"

--- a/code/game/objects/structures/crates_lockers/closets/secure/scientist.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/scientist.dm
@@ -25,6 +25,7 @@
 	// Traitor steal objectives
 	new /obj/item/clothing/suit/armor/reactive/teleport(src)
 	new /obj/item/laser_pointer(src)
+	new /obj/item/card/id/departmental_budget/sci(src)
 
 /obj/structure/closet/secure_closet/cytology
 	name = "cytology equipment locker"

--- a/code/game/objects/structures/crates_lockers/closets/secure/security.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/security.dm
@@ -48,6 +48,8 @@
 
 /obj/structure/closet/secure_closet/hop/populate_contents_immediate()
 	new /obj/item/gun/energy/e_gun(src)
+	new /obj/item/card/id/departmental_budget/srv(src)
+	new /obj/item/card/id/departmental_budget/civ(src)
 
 /obj/structure/closet/secure_closet/hos
 	name = "head of security's locker"
@@ -77,6 +79,7 @@
 	// Traitor steal objectives
 	new /obj/item/gun/energy/e_gun/hos(src)
 	new /obj/item/pinpointer/nuke(src)
+	new /obj/item/card/id/departmental_budget/sec(src)
 
 /obj/structure/closet/secure_closet/warden
 	name = "warden's locker"


### PR DESCRIPTION
## About The Pull Request

Grants all Heads of Staff their respective departmental budget cards and allows you to use all departmental budget cards on bank machines to access their funds. (Also adds all the new departmental budget cards as traitor steal objectives.)

All departmental budget cards are found within the personal lockers of each Head of Staff.

## Why It's Good For The Game

Allows people to money launder, access their department funds which have previously been vestigial, allow CE's with Power Exporters to rightfully claim their own credits produced by said Power Exporter, and give bank machines more purpose.

## Changelog

:cl:
add: Added all the previously non-existent Departmental Budget Cards.
add: Bank Machines can now accept departmental budget cards to switch between department accounts.
add: The Syndicate may task it's agents to steal any of the station's departmental budget cards.
/:cl: